### PR TITLE
Fixed indenting in xWebsite.config.ps1

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -1852,8 +1852,11 @@ function Set-LogCustomField
             sourceName = $customField.SourceName
             sourceType = $customField.SourceType
         }
+                
+        Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable
         
-        Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable        
+        # The second Set-WebConfigurationProperty is to handle an edge case where logfile.customFields is not updated correctly.  Maybe be caused by a possible bug in the IIS provider
+        Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable     
     }
 }
 

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -1855,7 +1855,7 @@ function Set-LogCustomField
                 
         Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable
         
-        # The second Set-WebConfigurationProperty is to handle an edge case where logfile.customFields is not updated correctly.  Maybe be caused by a possible bug in the IIS provider
+        # The second Set-WebConfigurationProperty is to handle an edge case where logfile.customFields is not updated correctly.  May be caused by a possible bug in the IIS provider
         Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable     
     }
 }

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -1847,17 +1847,13 @@ function Set-LogCustomField
 
     foreach ($customField in $LogCustomField)
     {
-        $filterString = "/system.applicationHost/sites/site[@name='{0}']/logFile/customFields/add[@logFieldName='{1}']" -f $Site, $customField.LogFieldName
-
         $addHashTable = @{
             logFieldName = $customField.LogFieldName
             sourceName = $customField.SourceName
             sourceType = $customField.SourceType
         }
         
-        #New-ItemProperty "IIS:\Sites\$Name" -Name 'logfile.customFields.collection' -Value $addHashTable
-        Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable 
-        
+        Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable        
     }
 }
 

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -154,7 +154,7 @@ function Get-TargetResource
         BindingInfo              = $cimBindings
         DefaultPage              = $allDefaultPages
         EnabledProtocols         = $website.EnabledProtocols
-        AuthenticationInfo       = $cimAuthentication
+        AuthenticationInfo       = [string[]]$cimAuthentication
         PreloadEnabled           = $website.applicationDefaults.preloadEnabled
         ServiceAutoStartProvider = $website.applicationDefaults.serviceAutoStartProvider
         ServiceAutoStartEnabled  = $website.applicationDefaults.serviceAutoStartEnabled
@@ -1854,17 +1854,10 @@ function Set-LogCustomField
             sourceName = $customField.SourceName
             sourceType = $customField.SourceType
         }
-
-        $presentCustomLog = Get-WebConfigurationProperty -Filter $filterString -Name "."
-
-        if ($presentCustomLog)
-        {
-            Set-ItemProperty "IIS:\Sites\$Name" -Name 'logfile.customFields.collection' -Value $addHashTable
-        }
-        else
-        {
-            New-ItemProperty "IIS:\Sites\$Name" -Name 'logfile.customFields.collection' -Value $addHashTable
-        }
+        
+        #New-ItemProperty "IIS:\Sites\$Name" -Name 'logfile.customFields.collection' -Value $addHashTable
+        Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/sites/site[@name='$Site']/logFile/customFields" -Name "." -Value $addHashTable 
+        
     }
 }
 

--- a/Tests/Integration/MSFT_xWebsite.config.ps1
+++ b/Tests/Integration/MSFT_xWebsite.config.ps1
@@ -27,7 +27,7 @@ configuration MSFT_xWebsite_Present_Started
                     Digest    = $Node.AuthenticationInfoDigest
                     Windows   = $Node.AuthenticationInfoWindows
                 }
-            BindingInfo = @(MSFT_xWebBindingInformation
+                BindingInfo = @(MSFT_xWebBindingInformation
                 {
                     Protocol              = $Node.HTTPProtocol
                     Port                  = $Node.HTTPPort
@@ -61,20 +61,20 @@ configuration MSFT_xWebsite_Present_Started
                     CertificateStoreName  = $Node.CertificateStoreName
                     SslFlags              = $Node.SslFlags
                 })
-            DefaultPage = $Node.DefaultPage
-            EnabledProtocols = $Node.EnabledProtocols
-            PhysicalPath = $Node.PhysicalPath
-            PreloadEnabled = $Node.PreloadEnabled
-            ServiceAutoStartEnabled = $Node.ServiceAutoStartEnabled
-            ServiceAutoStartProvider = $Node.ServiceAutoStartProvider
-            State = 'Started'
-            LogCustomFields    = @(
-                MSFT_xLogCustomFieldInformation
-                {
-                    LogFieldName = $Node.LogFieldName
-                    SourceName   = $Node.SourceName
-                    SourceType   = $Node.SourceType
-                }
+                DefaultPage = $Node.DefaultPage
+                EnabledProtocols = $Node.EnabledProtocols
+                PhysicalPath = $Node.PhysicalPath
+                PreloadEnabled = $Node.PreloadEnabled
+                ServiceAutoStartEnabled = $Node.ServiceAutoStartEnabled
+                ServiceAutoStartProvider = $Node.ServiceAutoStartProvider
+                State = 'Started'
+                LogCustomFields    = @(
+                    MSFT_xLogCustomFieldInformation
+                    {
+                        LogFieldName = $Node.LogFieldName
+                        SourceName   = $Node.SourceName
+                        SourceType   = $Node.SourceType
+                    }
             )
         }
     }


### PR DESCRIPTION
Only fixed indention.  Trying to repro the bug where the customLogging is applied to the wrong website by leveraging the integration tests